### PR TITLE
Context manager de transação no BaseRepository

### DIFF
--- a/backend/app/repositories/base.py
+++ b/backend/app/repositories/base.py
@@ -1,4 +1,30 @@
+from contextlib import contextmanager
+import sqlite3
+
+
 class BaseRepository:
-    def __init__(self, conn) -> None:
+    def __init__(self, conn: sqlite3.Connection):
         self.conn = conn
 
+    @contextmanager
+    def transaction(self, mode: str = "DEFERRED"):
+        """
+        Context manager para transações SQLite.
+
+        mode:
+            - DEFERRED (default)
+            - IMMEDIATE
+            - EXCLUSIVE
+        """
+
+        try:
+            # inicia transação com modo configurável
+            self.conn.execute(f"BEGIN {mode}")
+
+            yield  # executa o bloco dentro do "with"
+
+            self.conn.commit()
+
+        except Exception:
+            self.conn.rollback()
+            raise

--- a/backend/app/repositories/consulta_repository.py
+++ b/backend/app/repositories/consulta_repository.py
@@ -287,8 +287,7 @@ class ConsultaRepository(BaseRepository):
         data_hora_str = f"{data.isoformat()} {hora}:00"
         placeholders = ",".join(["?"] * len(medicos))
 
-        self.conn.execute("BEGIN IMMEDIATE")
-        try:
+        with self.transaction("IMMEDIATE"):
             cursor = self.conn.cursor()
 
             cursor.execute(
@@ -296,16 +295,18 @@ class ConsultaRepository(BaseRepository):
                 SELECT DISTINCT medico_id
                 FROM consultas
                 WHERE medico_id IN ({placeholders})
-                AND data_hora = ?
-                AND status != 'cancelada'
+                  AND data_hora = ?
+                  AND status != 'cancelada'
                 """,
                 (*medicos, data_hora_str),
             )
+
             busy = {int(r[0]) for r in cursor.fetchall()}
 
             medico_livre = next((m for m in medicos if m not in busy), None)
+
             if medico_livre is None:
-                self.conn.execute("ROLLBACK")
+                # ⚠️ importante: não precisa rollback manual
                 return None
 
             cursor.execute(
@@ -315,9 +316,11 @@ class ConsultaRepository(BaseRepository):
                 """,
                 (paciente_id, medico_livre, data_hora_str),
             )
-            self.conn.execute("COMMIT")
-            return int(cursor.lastrowid)
 
-        except Exception:
-            self.conn.execute("ROLLBACK")
-            raise
+            consulta_id = cursor.lastrowid
+            if consulta_id is None:
+                raise RuntimeError(
+                    "Falha ao obter ID da consulta inserida. "
+                    "Verifique se a tabela 'consultas' possui uma coluna PRIMARY KEY AUTOINCREMENT."
+                )
+            return int(consulta_id)


### PR DESCRIPTION
Adicionar método transaction(mode='DEFERRED') ao BaseRepository como context manager. Isso evita repetir o try/BEGIN/COMMIT/ROLLBACK em futuros repositórios que precisem de atomicidade, mantendo a consistência do padrão de código do projeto. with self.transaction('IMMEDIATE'):
    # operações atômicas

Esta tarefa é marcada como baixa prioridade pois T4 já implementa o padrão diretamente. T7 é uma refatoração para manter o código mais limpo a longo prazo.